### PR TITLE
Implement RovingTabIndexMixin and 2 other mixins

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,7 @@
     "project": "./tsconfig.json"
   },
   "rules": {
+    "max-classes-per-file": "off",
     "no-console": [ "error", { "allow": ["warn"] } ]
   },
   "overrides": [
@@ -19,7 +20,6 @@
         "sinon": false
       },
       "rules": {
-        "max-classes-per-file": "off",
         "no-unused-expressions": "off"
       }
     }

--- a/packages/keyboard-direction-mixin/LICENSE
+++ b/packages/keyboard-direction-mixin/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2019 Vaadin Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/keyboard-direction-mixin/README.md
+++ b/packages/keyboard-direction-mixin/README.md
@@ -1,0 +1,9 @@
+# @vaadin/keyboard-direction-mixin
+
+This package provides `KeyboardDirectionMixin` that does the following:
+
+1. Add `keydown` listener on the element
+
+2. Navigate through `items` via arrow keys, <kbd>Home</kbd> and <kbd>End</kbd>
+
+The mixin accepts a class that must apply `SlottedItemsMixin`.

--- a/packages/keyboard-direction-mixin/keyboard-direction-class.ts
+++ b/packages/keyboard-direction-mixin/keyboard-direction-class.ts
@@ -1,0 +1,11 @@
+import { LitElement } from 'lit-element';
+
+export abstract class KeyboardDirectionClass extends LitElement {
+  protected _focus?(item: HTMLElement): void;
+
+  protected _isNextKey?(key: string): boolean;
+
+  protected _isPrevKey?(key: string): boolean;
+
+  protected _onKeyDown?(event: KeyboardEvent): void;
+}

--- a/packages/keyboard-direction-mixin/keyboard-direction-mixin.ts
+++ b/packages/keyboard-direction-mixin/keyboard-direction-mixin.ts
@@ -1,0 +1,126 @@
+import { PropertyValues } from 'lit-element';
+import { SlottedItemsInterface } from '@vaadin/slotted-items-mixin';
+import { KeyboardDirectionClass } from './keyboard-direction-class';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Constructor<T = object> = new (...args: any[]) => T;
+
+export interface KeyboardDirectionInterface {
+  focused: Element | null;
+}
+
+export type ItemCondition = (item: Element) => boolean;
+
+export const isFocusable: ItemCondition = (item: Element) =>
+  !item.hasAttribute('disabled') && !item.hasAttribute('hidden');
+
+/**
+ * Returns index of the next item that satisfies the given condition,
+ * based on the index of the current item and a numeric increment.
+ *
+ * @param {Element[]} items - array of items to iterate over
+ * @param {number} index - index of the current item
+ * @param {number} increment - numeric increment, can be either 1 or -1
+ * @param {ItemCondition} condition - function that accepts item as a parameter
+ */
+export const getAvailableIndex = (
+  items: Element[],
+  index: number,
+  increment: number,
+  condition: ItemCondition
+): number => {
+  const totalItems = items.length;
+  let idx = index;
+  for (let i = 0; typeof idx === 'number' && i < totalItems; i += 1, idx += increment || 1) {
+    if (idx < 0) {
+      idx = totalItems - 1;
+    } else if (idx >= totalItems) {
+      idx = 0;
+    }
+
+    const item = items[idx];
+    if (condition(item)) {
+      return idx;
+    }
+  }
+  return -1;
+};
+
+export const KeyboardDirectionMixin = <
+  T extends Constructor<SlottedItemsInterface & KeyboardDirectionClass>
+>(
+  base: T
+): Constructor<KeyboardDirectionClass & KeyboardDirectionInterface> & T => {
+  class KeyboardDirection extends base {
+    focus() {
+      const first = this.items.length ? this.items[0] : null;
+
+      if (first) {
+        first.focus();
+      }
+    }
+
+    get focused() {
+      const root = (this.getRootNode() as unknown) as DocumentOrShadowRoot;
+      return root ? (root.activeElement as HTMLElement) : null;
+    }
+
+    protected firstUpdated(props: PropertyValues) {
+      super.firstUpdated(props);
+
+      this.addEventListener('keydown', (event: KeyboardEvent) => {
+        this._onKeyDown(event);
+      });
+    }
+
+    protected _onKeyDown(event: KeyboardEvent) {
+      if (event.metaKey || event.ctrlKey) {
+        return;
+      }
+
+      const { key } = event;
+      const { items, focused } = this;
+      const currentIdx = items.findIndex(item => focused === item);
+
+      let idx;
+      let increment;
+
+      if (this._isPrevKey(key)) {
+        increment = -1;
+        idx = currentIdx - 1;
+      } else if (this._isNextKey(key)) {
+        increment = 1;
+        idx = currentIdx + 1;
+      } else if (key === 'Home') {
+        increment = 1;
+        idx = 0;
+      } else if (key === 'End') {
+        increment = -1;
+        idx = items.length - 1;
+      }
+
+      idx = getAvailableIndex(items, idx as number, increment as number, isFocusable);
+      if (idx >= 0) {
+        event.preventDefault();
+        const item = items[idx] as HTMLElement;
+        if (item) {
+          this._focus(item);
+        }
+      }
+    }
+
+    protected _isPrevKey(key: string) {
+      return key === 'ArrowUp' || key === 'ArrowLeft';
+    }
+
+    protected _isNextKey(key: string) {
+      return key === 'ArrowDown' || key === 'ArrowRight';
+    }
+
+    protected _focus(item: HTMLElement) {
+      item.focus();
+    }
+  }
+
+  return KeyboardDirection;
+};

--- a/packages/keyboard-direction-mixin/package.json
+++ b/packages/keyboard-direction-mixin/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@vaadin/keyboard-direction-mixin",
+  "version": "0.0.0",
+  "author": "Vaadin Ltd",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vaadin/component-mixins.git",
+    "directory": "packages/keyboard-direction-mixin"
+  },
+  "main": "keyboard-direction-mixin.js",
+  "module": "keyboard-direction-mixin.js",
+  "files": [
+    "keyboard-direction-*.d.ts*",
+    "keyboard-direction-*.js*"
+  ],
+  "dependencies": {
+    "@vaadin/slotted-items-mixin": "^0.0.0",
+    "lit-element": "^2.0.0",
+    "lit-html": "^1.0.0"
+  },
+  "devDependencies": {
+    "@open-wc/testing-helpers": "^1.2.1",
+    "@vaadin/test-helpers": "^0.1.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/keyboard-direction-mixin/test/keyboard-direction-mixin.test.ts
+++ b/packages/keyboard-direction-mixin/test/keyboard-direction-mixin.test.ts
@@ -1,0 +1,136 @@
+import { LitElement, html, customElement } from 'lit-element';
+import { fixture } from '@open-wc/testing-helpers';
+import { arrowDown, arrowLeft, arrowRight, arrowUp, end, home } from '@vaadin/test-helpers';
+import { SlottedItemsMixin } from '@vaadin/slotted-items-mixin';
+import { KeyboardDirectionMixin } from '../keyboard-direction-mixin';
+
+const { expect } = chai;
+
+@customElement('kdm-element')
+class KdmElement extends KeyboardDirectionMixin(SlottedItemsMixin(LitElement)) {
+  render() {
+    return html`
+      <style>
+        :host {
+          display: block;
+        }
+
+        div {
+          display: flex;
+          flex-direction: column;
+        }
+      </style>
+      <div>
+        <slot></slot>
+      </div>
+    `;
+  }
+}
+
+describe('KeyboardDirectionMixin', () => {
+  let element: KdmElement;
+  let items: HTMLElement[];
+
+  beforeEach(async () => {
+    element = await fixture(html`
+      <kdm-element>
+        <div tabindex="0">Foo</div>
+        <div tabindex="0">Bar</div>
+        <div disabled tabindex="-1">Bay</div>
+        <div tabindex="0">Baz</div>
+      </kdm-element>
+    `);
+
+    element.focus();
+    items = element.items;
+  });
+
+  it('should set focused to first item by default', () => {
+    expect(element.focused).to.equal(items[0]);
+  });
+
+  it('should not move focus when "ctrl" is pressed on "arrow-down" key', () => {
+    arrowDown(element, 'ctrl');
+    expect(element.focused).to.equal(items[0]);
+  });
+
+  it('should not move focus when "meta" is pressed on "arrow-down" key', () => {
+    arrowDown(element, 'meta');
+    expect(element.focused).to.equal(items[0]);
+  });
+
+  it('should move focus to next item on "arrow-down" key', () => {
+    arrowDown(element);
+    expect(element.focused).to.equal(items[1]);
+  });
+
+  it('should move focus to next item on "arrow-right" key', () => {
+    arrowRight(element);
+    expect(element.focused).to.equal(items[1]);
+  });
+
+  it('should move focus to prev item on "arrow-up" key', () => {
+    arrowDown(element);
+    arrowUp(element);
+    expect(element.focused).to.equal(items[0]);
+  });
+
+  it('should move focus to prev item on "arrow-left" key', () => {
+    arrowRight(element);
+    arrowLeft(element);
+    expect(element.focused).to.equal(items[0]);
+  });
+
+  it('should move focus to last item on "end" keydown', () => {
+    end(element);
+    expect(element.focused).to.equal(items[3]);
+  });
+
+  it('should move focus to the first item on "home" key', () => {
+    end(element);
+    home(element);
+    expect(element.focused).to.equal(items[0]);
+  });
+
+  it('should move focus to the first enabled item on "home" key', () => {
+    end(element);
+    items[0].setAttribute('disabled', '');
+    home(element);
+    expect(element.focused).to.equal(items[1]);
+  });
+
+  it('should move focus to the closest enabled item on "end" key', () => {
+    element.items[3].setAttribute('disabled', '');
+    end(element);
+    expect(element.focused).to.equal(items[1]);
+  });
+
+  it('should move focus to the first item on "arrow-down" key on the last item', () => {
+    end(element);
+    arrowDown(element);
+    expect(element.focused).to.equal(items[0]);
+  });
+
+  it('should move focus to the last item on "arrow-up" key on the first item', () => {
+    arrowUp(element);
+    expect(element.focused).to.equal(items[3]);
+  });
+
+  it('should ignore and skip items with "disabled" attribute when moving focus', () => {
+    arrowDown(element);
+    arrowDown(element);
+    expect(element.focused).to.equal(items[3]);
+  });
+
+  it('should ignore and skip items with "hidden" attribute when moving focus', () => {
+    element.items[1].setAttribute('hidden', '');
+    arrowDown(element);
+    expect(element.focused).to.equal(items[3]);
+  });
+
+  it('should not throw when calling focus before element is attached', () => {
+    expect(() => {
+      document.createElement('rtm-element').focus();
+    }).to.not.throw(Error);
+  });
+});

--- a/packages/keyboard-direction-mixin/tsconfig.json
+++ b/packages/keyboard-direction-mixin/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "outDir": ".",
+  "compilerOptions": {
+    "composite": true
+  },
+  "include": [
+    "keyboard-direction-*.ts"
+  ]
+}

--- a/packages/roving-tabindex-mixin/LICENSE
+++ b/packages/roving-tabindex-mixin/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2019 Vaadin Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/roving-tabindex-mixin/README.md
+++ b/packages/roving-tabindex-mixin/README.md
@@ -1,0 +1,9 @@
+# @vaadin/roving-tabindex-mixin
+
+This package provides `RovingTabIndexMixin` that does the following:
+
+1. When one of the items receives focus, set its `tabIndex` to 0
+
+2. Set `tabIndex` to -1 for all the items except the focused one
+
+The mixin accepts a class that must apply `SlottedItemsMixin` and `KeyboardDirectionMixin`.

--- a/packages/roving-tabindex-mixin/package.json
+++ b/packages/roving-tabindex-mixin/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@vaadin/roving-tabindex-mixin",
+  "version": "0.0.0",
+  "author": "Vaadin Ltd",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vaadin/component-mixins.git",
+    "directory": "packages/roving-tabindex-mixin"
+  },
+  "main": "roving-tabindex-mixin.js",
+  "module": "roving-tabindex-mixin.js",
+  "files": [
+    "roving-tabindex-*.d.ts*",
+    "roving-tabindex-*.js*"
+  ],
+  "dependencies": {
+    "@vaadin/keyboard-direction-mixin": "^0.0.0",
+    "@vaadin/slotted-items-mixin": "^0.0.0",
+    "lit-element": "^2.0.0",
+    "lit-html": "^1.0.0"
+  },
+  "devDependencies": {
+    "@open-wc/testing-helpers": "^1.2.1",
+    "@vaadin/test-helpers": "^0.1.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/roving-tabindex-mixin/roving-tabindex-class.ts
+++ b/packages/roving-tabindex-mixin/roving-tabindex-class.ts
@@ -1,0 +1,7 @@
+import { LitElement } from 'lit-element';
+
+export abstract class RovingTabIndexClass extends LitElement {
+  protected _setFocusable?(idx: number): void;
+
+  protected _setTabIndex?(item: HTMLElement): void;
+}

--- a/packages/roving-tabindex-mixin/roving-tabindex-mixin.ts
+++ b/packages/roving-tabindex-mixin/roving-tabindex-mixin.ts
@@ -1,0 +1,65 @@
+import {
+  KeyboardDirectionInterface,
+  getAvailableIndex,
+  isFocusable
+} from '@vaadin/keyboard-direction-mixin';
+import { KeyboardDirectionClass } from '@vaadin/keyboard-direction-mixin/keyboard-direction-class';
+import { SlottedItemsInterface } from '@vaadin/slotted-items-mixin';
+import { SlottedItemsClass } from '@vaadin/slotted-items-mixin/slotted-items-class';
+import { RovingTabIndexClass } from './roving-tabindex-class';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Constructor<T = object> = new (...args: any[]) => T;
+
+export const RovingTabIndexMixin = <
+  T extends Constructor<
+    KeyboardDirectionClass &
+      KeyboardDirectionInterface &
+      SlottedItemsClass &
+      SlottedItemsInterface &
+      RovingTabIndexClass
+  >
+>(
+  base: T
+): T & Constructor<RovingTabIndexClass> => {
+  class RovingTabIndex extends base {
+    focus() {
+      const first =
+        (this.querySelector('[tabindex="0"]') as HTMLElement) ||
+        (this.items.length ? this.items[0] : null);
+      if (first) {
+        first.focus();
+      }
+    }
+
+    protected _itemsChanged(items: HTMLElement[], oldItems: HTMLElement[]) {
+      super._itemsChanged && super._itemsChanged(items, oldItems); // eslint-disable-line no-unused-expressions
+
+      if (items) {
+        const { focused } = this;
+        this._setFocusable(
+          focused && this.contains(focused) ? items.indexOf(focused as HTMLElement) : 0
+        );
+      }
+    }
+
+    protected _setFocusable(idx: number) {
+      const index = getAvailableIndex(this.items, idx, 1, isFocusable);
+      this._setTabIndex(this.items[index]);
+    }
+
+    protected _setTabIndex(item: HTMLElement) {
+      this.items.forEach((el: HTMLElement) => {
+        // eslint-disable-next-line no-param-reassign
+        el.tabIndex = el === item ? 0 : -1;
+      });
+    }
+
+    protected _focus(item: HTMLElement) {
+      super._focus && super._focus(item); // eslint-disable-line no-unused-expressions
+      this._setTabIndex(item);
+    }
+  }
+
+  return RovingTabIndex;
+};

--- a/packages/roving-tabindex-mixin/test/roving-tabindex-mixin.test.ts
+++ b/packages/roving-tabindex-mixin/test/roving-tabindex-mixin.test.ts
@@ -1,0 +1,161 @@
+import { LitElement, html, customElement } from 'lit-element';
+import { fixture } from '@open-wc/testing-helpers';
+import { arrowDown, arrowLeft, arrowRight, arrowUp, end, home, tab } from '@vaadin/test-helpers';
+import { KeyboardDirectionMixin } from '@vaadin/keyboard-direction-mixin';
+import { SlottedItemsMixin } from '@vaadin/slotted-items-mixin';
+import { RovingTabIndexMixin } from '../roving-tabindex-mixin';
+
+const { expect } = chai;
+const { sinon } = window;
+
+@customElement('rtm-element')
+class RtmElement extends RovingTabIndexMixin(
+  KeyboardDirectionMixin(SlottedItemsMixin(LitElement))
+) {
+  render() {
+    return html`
+      <style>
+        :host {
+          display: block;
+        }
+
+        div {
+          display: flex;
+          flex-direction: column;
+        }
+      </style>
+      <div>
+        <slot></slot>
+      </div>
+    `;
+  }
+}
+
+describe('RovingTabIndexMixin', () => {
+  let element: RtmElement;
+  let items: HTMLElement[];
+
+  const expectTabIndexZero = (idx: number) => {
+    element.items.forEach((item, i) => expect(item.tabIndex).to.be.equal(i === idx ? 0 : -1));
+  };
+
+  beforeEach(async () => {
+    element = await fixture(html`
+      <rtm-element>
+        <div>Foo</div>
+        <div>Bar</div>
+        <div disabled>Bay</div>
+        <div>Baz</div>
+      </rtm-element>
+    `);
+
+    element.focus();
+    items = element.items;
+  });
+
+  it('should set tabIndex to -1 to all items, except the first one', () => {
+    expectTabIndexZero(0);
+  });
+
+  it('should not move tabIndex when "ctrl" is pressed on "arrow-down" key', () => {
+    arrowDown(element, 'ctrl');
+    expectTabIndexZero(0);
+  });
+
+  it('should not move tabIndex when "meta" is pressed on "arrow-down" key', () => {
+    arrowDown(element, 'meta');
+    expectTabIndexZero(0);
+  });
+
+  it('should move tabIndex to next item on "arrow-down" key', () => {
+    arrowDown(element);
+    expectTabIndexZero(1);
+  });
+
+  it('should move tabIndex to next item on "arrow-right" key', () => {
+    arrowRight(element);
+    expectTabIndexZero(1);
+  });
+
+  it('should move tabIndex to prev item on "arrow-up" key', () => {
+    arrowDown(element);
+    arrowUp(element);
+    expectTabIndexZero(0);
+  });
+
+  it('should move tabIndex to prev item on "arrow-left" key', () => {
+    arrowRight(element);
+    arrowLeft(element);
+    expectTabIndexZero(0);
+  });
+
+  it('should move tabIndex to last item on "end" keydown', () => {
+    end(element);
+    expectTabIndexZero(3);
+  });
+
+  it('should move tabIndex to the first item on "home" key', () => {
+    end(element);
+    home(element);
+    expectTabIndexZero(0);
+  });
+
+  it('should move tabIndex to the first enabled item on "home" key', () => {
+    end(element);
+    items[0].setAttribute('disabled', '');
+    home(element);
+    expectTabIndexZero(1);
+  });
+
+  it('should move tabIndex to the closest enabled item on "end" key', () => {
+    element.items[3].setAttribute('disabled', '');
+    end(element);
+    expectTabIndexZero(1);
+  });
+
+  it('should move tabIndex to the first item on "arrow-down" key on the last item', () => {
+    end(element);
+    arrowDown(element);
+    expectTabIndexZero(0);
+  });
+
+  it('should move tabIndex to the last item on "arrow-up" key on the first item', () => {
+    arrowUp(element);
+    expectTabIndexZero(3);
+  });
+
+  it('should ignore and skip items with "disabled" attribute when moving tabIndex', () => {
+    arrowDown(element);
+    arrowDown(element);
+    expectTabIndexZero(3);
+  });
+
+  it('should ignore and skip items with "hidden" attribute when moving tabIndex', () => {
+    element.items[1].setAttribute('hidden', '');
+    arrowDown(element);
+    expectTabIndexZero(3);
+  });
+
+  it('should not throw when calling focus before element is attached', () => {
+    expect(() => {
+      document.createElement('rtm-element').focus();
+    }).to.not.throw(Error);
+  });
+
+  it('should re-focus previously focused item when moving focus back', async () => {
+    arrowDown(element);
+    tab(element);
+    const spy = sinon.spy(element.items[1], 'focus');
+    element.focus();
+    await element.updateComplete;
+    expect(spy).to.be.calledOnce;
+    expectTabIndexZero(1);
+  });
+
+  it('should set tabIndex to -1 on the newly added item', async () => {
+    const item = document.createElement('div');
+    element.appendChild(item);
+    await element.updateComplete;
+    expect(item.tabIndex).to.equal(-1);
+  });
+});

--- a/packages/roving-tabindex-mixin/tsconfig.json
+++ b/packages/roving-tabindex-mixin/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "outDir": ".",
+  "compilerOptions": {
+    "composite": true
+  },
+  "include": [
+    "roving-tabindex-*.ts"
+  ]
+}

--- a/packages/slotted-items-mixin/LICENSE
+++ b/packages/slotted-items-mixin/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2019 Vaadin Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/slotted-items-mixin/README.md
+++ b/packages/slotted-items-mixin/README.md
@@ -1,0 +1,9 @@
+# @vaadin/slotted-items-mixin
+
+This package provides `SlottedItemsMixin` that does the following:
+
+1. Set read-only `items` property based on the light DOM children
+
+2. Add `slotchange` listener on the default `slot` to update items
+
+3. Dispatch `items-changed` event when `items` value is changed

--- a/packages/slotted-items-mixin/package.json
+++ b/packages/slotted-items-mixin/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@vaadin/slotted-items-mixin",
+  "version": "0.0.0",
+  "author": "Vaadin Ltd",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vaadin/component-mixins.git",
+    "directory": "packages/slotted-items-mixin"
+  },
+  "main": "slotted-items-mixin.js",
+  "module": "slotted-items-mixin.js",
+  "files": [
+    "slotted-items-*.d.ts*",
+    "slotted-items-*.js*"
+  ],
+  "dependencies": {
+    "lit-element": "^2.0.0",
+    "lit-html": "^1.0.0"
+  },
+  "devDependencies": {
+    "@open-wc/testing-helpers": "^1.2.1",
+    "@vaadin/test-helpers": "^0.1.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/slotted-items-mixin/slotted-items-class.ts
+++ b/packages/slotted-items-mixin/slotted-items-class.ts
@@ -1,0 +1,7 @@
+import { LitElement } from 'lit-element';
+
+export abstract class SlottedItemsClass extends LitElement {
+  protected _itemsChanged?(items: HTMLElement[], oldItems: HTMLElement[]): void;
+
+  protected _filterItems?(): HTMLElement[];
+}

--- a/packages/slotted-items-mixin/slotted-items-mixin.ts
+++ b/packages/slotted-items-mixin/slotted-items-mixin.ts
@@ -1,0 +1,72 @@
+import { property, PropertyValues } from 'lit-element';
+import { SlottedItemsClass } from './slotted-items-class';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Constructor<T = object> = new (...args: any[]) => T;
+
+export interface SlottedItemsInterface {
+  items: HTMLElement[];
+}
+
+export const SlottedItemsMixin = <T extends Constructor<SlottedItemsClass>>(
+  base: T
+): Constructor<SlottedItemsClass & SlottedItemsInterface> & T => {
+  class SlottedItems extends base {
+    @property({ attribute: false, hasChanged: () => true })
+    protected _items: HTMLElement[] = [];
+
+    get items(): HTMLElement[] {
+      return this._items;
+    }
+
+    connectedCallback() {
+      super.connectedCallback();
+
+      this._items = this._filterItems();
+    }
+
+    protected update(props: PropertyValues) {
+      /* istanbul ignore else */
+      if (props.has('_items')) {
+        this._itemsChanged(this._items, (props.get('_items') || []) as HTMLElement[]);
+      }
+
+      super.update(props);
+    }
+
+    protected firstUpdated(props: PropertyValues) {
+      super.firstUpdated(props);
+
+      const slot = this.renderRoot.querySelector('slot');
+      /* istanbul ignore else */
+      if (slot) {
+        slot.addEventListener('slotchange', () => {
+          this._items = this._filterItems();
+        });
+      }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    protected _itemsChanged(items: HTMLElement[], _oldItems: HTMLElement[]) {
+      this.dispatchEvent(
+        new CustomEvent('items-changed', {
+          detail: {
+            value: items
+          }
+        })
+      );
+    }
+
+    protected _filterItems() {
+      return Array.from(this.children) as HTMLElement[];
+    }
+  }
+
+  return SlottedItems;
+};
+
+declare global {
+  interface HTMLElementEventMap {
+    'items-changed': CustomEvent;
+  }
+}

--- a/packages/slotted-items-mixin/test/slotted-items-mixin.test.ts
+++ b/packages/slotted-items-mixin/test/slotted-items-mixin.test.ts
@@ -1,0 +1,69 @@
+import { LitElement, html, customElement } from 'lit-element';
+import { fixture, nextFrame } from '@open-wc/testing-helpers';
+import { SlottedItemsMixin } from '../slotted-items-mixin';
+
+const { expect } = chai;
+const { sinon } = window;
+
+@customElement('sim-element')
+class SimElement extends SlottedItemsMixin(LitElement) {
+  render() {
+    return html`
+      <style>
+        :host {
+          display: block;
+        }
+      </style>
+      <slot></slot>
+    `;
+  }
+}
+
+describe('SlottedItemsMixin', () => {
+  let element: SimElement;
+
+  beforeEach(async () => {
+    element = await fixture(html`
+      <sim-element>
+        <div>
+          <span>Item 1</span>
+        </div>
+        <div>
+          <span>Item 2</span>
+        </div>
+        <div>Item 3</div>
+      </sim-element>
+    `);
+  });
+
+  describe('items', () => {
+    it('should set `items` to the array of child nodes', () => {
+      expect(element.items).to.be.an('array');
+      expect(element.items.length).to.be.equal(3);
+    });
+
+    it('should update `items` value when removing nodes', async () => {
+      element.removeChild(element.items[2]);
+      await element.updateComplete;
+      expect(element.items.length).to.be.equal(2);
+    });
+
+    it('should update `items` value when adding nodes', async () => {
+      const div = document.createElement('div');
+      element.appendChild(div);
+      await element.updateComplete;
+      expect(element.items.length).to.be.equal(4);
+    });
+
+    it('should fire `items-changed` event on items change', async () => {
+      const spy = sinon.spy();
+      element.addEventListener('items-changed', spy);
+      const div = document.createElement('div');
+      element.appendChild(div);
+      await nextFrame();
+      expect(spy).to.be.calledOnce;
+      expect(spy.firstCall.args[0]).to.be.instanceOf(CustomEvent);
+      expect(spy.firstCall.args[0].detail.value).to.deep.equal(element.items);
+    });
+  });
+});

--- a/packages/slotted-items-mixin/tsconfig.json
+++ b/packages/slotted-items-mixin/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "outDir": ".",
+  "compilerOptions": {
+    "composite": true
+  },
+  "include": [
+    "slotted-items-*.ts"
+  ]
+}


### PR DESCRIPTION
Fixes #4 

This PR contains the 3 mixins prototyped at vaadin/vaadin-accordion#30

1. `SlottedItemsMixin`
2. `KeyboardDirectionMixin`
3. `RovingTabIndexMixin`

They are needed for the following components:

- `vaadin-accordion`: 1 and 2 only
- `vaadin-tabs`: 1, 2 3
- `vaadin-list-box`: 1, 2, 3