### PR TITLE
fix(selected-state-mixin): correct lifecycle

### DIFF
--- a/packages/selected-state-mixin/selected-state-mixin.ts
+++ b/packages/selected-state-mixin/selected-state-mixin.ts
@@ -26,11 +26,11 @@ export const SelectedStateMixin = <
     @property({ type: Boolean, reflect: true }) selected = false;
 
     protected update(props: PropertyValues) {
-      super.update(props);
-
       if (props.has('disabled') && this.disabled) {
         this.selected = false;
       }
+
+      super.update(props);
     }
 
     protected updated(props: PropertyValues) {

--- a/packages/selected-state-mixin/test/selected-state-mixin.test.ts
+++ b/packages/selected-state-mixin/test/selected-state-mixin.test.ts
@@ -49,8 +49,10 @@ describe('SelectedStateMixin', () => {
 
   it('should set selected property to false when disabled is set to true', async () => {
     element.selected = true;
+    await element.updateComplete;
     element.disabled = true;
     await element.updateComplete;
     expect(element.selected).to.equal(false);
+    expect(element.hasAttribute('selected')).to.equal(false);
   });
 });


### PR DESCRIPTION
By toggling `selected` before `super.update` we ensure it reflects to attribute properly.