### PR TITLE
feat: implement media-query-mixin

### DIFF
--- a/packages/media-query-mixin/README.md
+++ b/packages/media-query-mixin/README.md
@@ -1,0 +1,24 @@
+# @vaadin/media-query-mixin
+
+This package provides `MediaQueryMixin` and `@mediaProperty` decorator.
+
+```ts
+@customElement('mq-basic-element')
+class MyElement extends MediaQueryMixin(LitElement) {
+
+  @mediaProperty({ media: '(max-width: 420px)' })
+  fullscreen: boolean | null | undefined;
+}
+```
+
+## Using a `@mediaProperty` decorator
+
+When using `@mediaProperty`, the following restrictions apply:
+
+- property is forced to be of `type: Boolean` regardless of the user config
+- property value is set to `true` when query matches, and `false` otherwise
+- `attribute: false` is forced so setting attribute is ignored
+- property is read-only so manual modifications are ignored
+- default property value set by the user is also ignored
+
+As a result, `window.matchMedia` is a single source of truth.

--- a/packages/media-query-mixin/media-query-class.ts
+++ b/packages/media-query-mixin/media-query-class.ts
@@ -1,5 +1,0 @@
-import { LitElement } from 'lit-element';
-
-export abstract class MediaQueryClass extends LitElement {
-  static mediaQueries: { [key: string]: unknown };
-}

--- a/packages/media-query-mixin/media-query-class.ts
+++ b/packages/media-query-mixin/media-query-class.ts
@@ -1,0 +1,5 @@
+import { LitElement } from 'lit-element';
+
+export abstract class MediaQueryClass extends LitElement {
+  static mediaQueries: { [key: string]: unknown };
+}

--- a/packages/media-query-mixin/media-query-mixin.ts
+++ b/packages/media-query-mixin/media-query-mixin.ts
@@ -61,6 +61,7 @@ export const MediaQueryMixin = <T extends Constructor<LitElement>>(
             const oldValue = ((this as {}) as { [key: string]: unknown })[prop];
             ((this as {}) as { [key: string]: unknown })[key] = value;
             this.requestUpdate(name, oldValue);
+            MediaQuery._mediaQueries[prop].updating = false;
           },
           configurable: true,
           enumerable: true
@@ -80,11 +81,6 @@ export const MediaQueryMixin = <T extends Constructor<LitElement>>(
           // allow property modification
           queries[prop].updating = true;
           ((this as {}) as { [key: string]: unknown })[prop] = query.matches;
-
-          // disallow property modification
-          Promise.resolve().then(() => {
-            queries[prop].updating = false;
-          });
         };
 
         // Store handlers in constructor to handle default attribute value if set,

--- a/packages/media-query-mixin/media-query-mixin.ts
+++ b/packages/media-query-mixin/media-query-mixin.ts
@@ -46,6 +46,8 @@ export const MediaQueryMixin = <T extends Constructor<LitElement>>(
         const query = window.matchMedia(media as string);
         this._mediaQueries[prop] = { query };
 
+        // Create custom accessors to disallow external property modifications. See original code at
+        // https://github.com/Polymer/lit-element/blob/41e9fd3/src/lib/updating-element.ts#L306-L320
         const key = `__${prop}`;
         Object.defineProperty(this.prototype, prop, {
           get(): boolean | null | undefined {

--- a/packages/media-query-mixin/media-query-mixin.ts
+++ b/packages/media-query-mixin/media-query-mixin.ts
@@ -66,9 +66,8 @@ export const MediaQueryMixin = <T extends Constructor<LitElement>>(
       }
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    constructor(...args: any[]) {
-      super(...args);
+    connectedCallback() {
+      super.connectedCallback();
 
       const queries = MediaQuery._mediaQueries;
 
@@ -80,21 +79,9 @@ export const MediaQueryMixin = <T extends Constructor<LitElement>>(
           ((this as {}) as { [key: string]: unknown })[prop] = query.matches;
         };
 
-        // Store handlers in constructor to handle default attribute value if set,
-        // which can be done in attributeChangedCallback before connectedCallback
-        this._boundQueries[prop] = handler;
-      });
-    }
-
-    connectedCallback() {
-      super.connectedCallback();
-
-      const queries = MediaQuery._mediaQueries;
-
-      Object.keys(queries).forEach(prop => {
-        const { query } = queries[prop];
-        const handler = this._boundQueries[prop];
         query.addListener(handler);
+        this._boundQueries[prop] = handler;
+
         // Set default value
         handler();
       });

--- a/packages/media-query-mixin/media-query-mixin.ts
+++ b/packages/media-query-mixin/media-query-mixin.ts
@@ -21,8 +21,6 @@ export const MediaQueryMixin = <T extends Constructor<LitElement>>(
       [prop: string]: { query: MediaQueryList; updating?: boolean };
     } = {};
 
-    private static _queryProps: Set<string> = new Set();
-
     private _boundQueries: { [prop: string]: () => void } = {};
 
     /**
@@ -47,7 +45,6 @@ export const MediaQueryMixin = <T extends Constructor<LitElement>>(
       if (isMediaString) {
         const query = window.matchMedia(media as string);
         this._mediaQueries[prop] = { query };
-        this._queryProps.add(prop);
 
         const key = `__${prop}`;
         Object.defineProperty(this.prototype, prop, {
@@ -73,9 +70,9 @@ export const MediaQueryMixin = <T extends Constructor<LitElement>>(
     constructor(...args: any[]) {
       super(...args);
 
-      const { _queryProps: props, _mediaQueries: queries } = MediaQuery;
+      const queries = MediaQuery._mediaQueries;
 
-      props.forEach(prop => {
+      Object.keys(queries).forEach(prop => {
         const { query } = queries[prop];
         const handler = () => {
           // allow property modification
@@ -92,9 +89,9 @@ export const MediaQueryMixin = <T extends Constructor<LitElement>>(
     connectedCallback() {
       super.connectedCallback();
 
-      const { _queryProps: props, _mediaQueries: queries } = MediaQuery;
+      const queries = MediaQuery._mediaQueries;
 
-      props.forEach(prop => {
+      Object.keys(queries).forEach(prop => {
         const { query } = queries[prop];
         const handler = this._boundQueries[prop];
         query.addListener(handler);
@@ -106,9 +103,9 @@ export const MediaQueryMixin = <T extends Constructor<LitElement>>(
     disconnectedCallback() {
       super.disconnectedCallback();
 
-      const { _queryProps: props, _mediaQueries: queries } = MediaQuery;
+      const queries = MediaQuery._mediaQueries;
 
-      props.forEach(prop => {
+      Object.keys(queries).forEach(prop => {
         const { query } = queries[prop];
         const handler = this._boundQueries[prop];
         query.removeListener(handler);

--- a/packages/media-query-mixin/media-query-mixin.ts
+++ b/packages/media-query-mixin/media-query-mixin.ts
@@ -1,0 +1,79 @@
+import { UpdatingElement, PropertyDeclaration } from 'lit-element/lib/updating-element.js';
+
+export abstract class MediaQueryClass extends UpdatingElement {
+  static mediaQueries: { [key: string]: unknown };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Constructor<T = object> = new (...args: any[]) => T;
+
+export const MediaQueryMixin = <T extends Constructor<UpdatingElement>>(
+  base: T
+): T & Constructor<MediaQueryClass> => {
+  class MediaQuery extends base {
+    static get mediaQueries() {
+      return {};
+    }
+
+    private static _mediaQueries: { [key: string]: { query: MediaQueryList; prop: string } } = {};
+
+    private _boundQueryHandlers: { [key: string]: () => void } = {};
+
+    /**
+     * Extend the LitElement `createProperty` method to map properties to events
+     */
+    static createProperty(name: PropertyKey, options: PropertyDeclaration) {
+      const mq = (this.mediaQueries as { [key: string]: unknown })[name as string];
+      const needQuery = typeof mq === 'string';
+
+      // @ts-ignore
+      super.createProperty(
+        name,
+        options
+        /*
+        needQuery
+          ? {
+              ...options,
+              noAccessor: true
+            }
+          : options
+        */
+      );
+
+      if (needQuery) {
+        const query = window.matchMedia(mq as string);
+        const prop = name as string;
+        this._mediaQueries[mq as string] = { prop, query };
+      }
+    }
+
+    connectedCallback() {
+      super.connectedCallback();
+
+      const queries = MediaQuery._mediaQueries;
+
+      Object.keys(queries).forEach(key => {
+        const { query, prop } = queries[key];
+        const handler = () => {
+          ((this as {}) as { [key: string]: unknown })[prop] = query.matches;
+        };
+        query.addListener(handler);
+        this._boundQueryHandlers[key] = handler;
+      });
+    }
+
+    disconnectedCallback() {
+      super.disconnectedCallback();
+
+      const queries = MediaQuery._mediaQueries;
+
+      Object.keys(queries).forEach(key => {
+        const handler = this._boundQueryHandlers[key];
+        queries[key].query.removeListener(handler);
+        delete this._boundQueryHandlers[key];
+      });
+    }
+  }
+
+  return MediaQuery;
+};

--- a/packages/media-query-mixin/media-query-mixin.ts
+++ b/packages/media-query-mixin/media-query-mixin.ts
@@ -23,9 +23,7 @@ export const MediaQueryMixin = <T extends Constructor<LitElement>>(
 
     private static _queryProps: Set<string> = new Set();
 
-    private _boundQueries: {
-      [prop: string]: { handler: () => void };
-    } = {};
+    private _boundQueries: { [prop: string]: () => void } = {};
 
     /**
      * Extend the LitElement `createProperty` method to watch media query.
@@ -91,7 +89,7 @@ export const MediaQueryMixin = <T extends Constructor<LitElement>>(
 
         // Store handlers in constructor to handle default attribute value if set,
         // which can be done in attributeChangedCallback before connectedCallback
-        this._boundQueries[prop] = { handler };
+        this._boundQueries[prop] = handler;
       });
     }
 
@@ -102,7 +100,7 @@ export const MediaQueryMixin = <T extends Constructor<LitElement>>(
 
       props.forEach(prop => {
         const { query } = queries[prop];
-        const { handler } = this._boundQueries[prop];
+        const handler = this._boundQueries[prop];
         query.addListener(handler);
         // Set default value
         handler();
@@ -116,7 +114,7 @@ export const MediaQueryMixin = <T extends Constructor<LitElement>>(
 
       props.forEach(prop => {
         const { query } = queries[prop];
-        const { handler } = this._boundQueries[prop];
+        const handler = this._boundQueries[prop];
         query.removeListener(handler);
         delete this._boundQueries[prop];
       });

--- a/packages/media-query-mixin/package.json
+++ b/packages/media-query-mixin/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@vaadin/media-query-mixin",
+  "version": "0.0.0",
+  "author": "Vaadin Ltd",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vaadin/component-mixins.git",
+    "directory": "packages/media-query-mixin"
+  },
+  "main": "media-query-mixin.js",
+  "module": "media-query-mixin.js",
+  "files": [
+    "media-query-*.d.ts*",
+    "media-query-*.js*"
+  ],
+  "dependencies": {
+    "lit-element": "^2.0.0",
+    "lit-html": "^1.0.0"
+  },
+  "devDependencies": {
+    "@open-wc/testing-helpers": "^1.2.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/media-query-mixin/test/media-query-mixin.test.ts
+++ b/packages/media-query-mixin/test/media-query-mixin.test.ts
@@ -1,0 +1,75 @@
+import { LitElement, customElement, html, property } from 'lit-element';
+import { fixture } from '@open-wc/testing-helpers';
+import { MediaQueryMixin } from '../media-query-mixin';
+
+const { expect } = chai;
+
+const listeners: { [key: string]: () => void } = {};
+const queryMatches: { [key: string]: boolean } = {};
+
+const runQuery = (query: string, matches: boolean) => {
+  queryMatches[query] = matches;
+  listeners[query]();
+};
+
+const FULLSCREEN = '(max-width: 420px) and (max-heigh: 420px)';
+
+const origMatchMedia = window.matchMedia;
+window.matchMedia = (query: string) => {
+  return {
+    get matches() {
+      return queryMatches[query] as boolean;
+    },
+    addListener(listener: () => void) {
+      listeners[query] = listener;
+    },
+    removeListener(_listener) {
+      delete listeners[query];
+    }
+  } as MediaQueryList;
+};
+
+@customElement('mq-element')
+class MqElement extends MediaQueryMixin(LitElement) {
+  static get mediaQueries() {
+    return {
+      fullscreen: FULLSCREEN
+    };
+  }
+
+  @property({ type: Boolean }) fullscreen: boolean | null | undefined;
+
+  render() {
+    return html`
+      <div part="content">Content</div>
+    `;
+  }
+}
+
+describe('MediaQueryMixin', () => {
+  let element: MqElement;
+
+  beforeEach(async () => {
+    element = await fixture(`<mq-element></mq-element>`);
+  });
+
+  afterEach(() => {
+    Object.keys(queryMatches).forEach(key => {
+      delete queryMatches[key];
+    });
+  });
+
+  after(() => {
+    window.matchMedia = origMatchMedia;
+  });
+
+  it('should set property value to undefined by default', () => {
+    expect(element.fullscreen).to.be.undefined;
+  });
+
+  it('should set property value to true when query matches', async () => {
+    runQuery(FULLSCREEN, true);
+    await element.updateComplete;
+    expect(element.fullscreen).to.be.true;
+  });
+});

--- a/packages/media-query-mixin/test/media-query-mixin.test.ts
+++ b/packages/media-query-mixin/test/media-query-mixin.test.ts
@@ -12,7 +12,7 @@ const runQuery = (query: string, matches: boolean) => {
   listeners[query] && listeners[query]();
 };
 
-const FULLSCREEN = '(max-width: 420px) and (max-heigh: 420px)';
+const FULLSCREEN = '(max-width: 420px)';
 const RESPONSIVE = '(max-width: 600px)';
 
 const origMatchMedia = window.matchMedia;

--- a/packages/media-query-mixin/test/media-query-mixin.test.ts
+++ b/packages/media-query-mixin/test/media-query-mixin.test.ts
@@ -1,4 +1,4 @@
-import { LitElement, customElement, html, property } from 'lit-element';
+import { LitElement, html, customElement, property } from 'lit-element';
 import { fixture } from '@open-wc/testing-helpers';
 import { MediaQueryMixin } from '../media-query-mixin';
 
@@ -9,10 +9,11 @@ const queryMatches: { [key: string]: boolean } = {};
 
 const runQuery = (query: string, matches: boolean) => {
   queryMatches[query] = matches;
-  listeners[query]();
+  listeners[query] && listeners[query]();
 };
 
 const FULLSCREEN = '(max-width: 420px) and (max-heigh: 420px)';
+const RESPONSIVE = '(max-width: 600px)';
 
 const origMatchMedia = window.matchMedia;
 window.matchMedia = (query: string) => {
@@ -29,16 +30,7 @@ window.matchMedia = (query: string) => {
   } as MediaQueryList;
 };
 
-@customElement('mq-element')
-class MqElement extends MediaQueryMixin(LitElement) {
-  static get mediaQueries() {
-    return {
-      fullscreen: FULLSCREEN
-    };
-  }
-
-  @property({ type: Boolean }) fullscreen: boolean | null | undefined;
-
+class MqElementBase extends MediaQueryMixin(LitElement) {
   render() {
     return html`
       <div part="content">Content</div>
@@ -47,10 +39,103 @@ class MqElement extends MediaQueryMixin(LitElement) {
 }
 
 describe('MediaQueryMixin', () => {
-  let element: MqElement;
+  describe('static get mediaQueries', () => {
+    @customElement('mq-basic-element')
+    class MqBasicElement extends MqElementBase {
+      static get mediaQueries() {
+        return {
+          fullscreen: FULLSCREEN
+        };
+      }
 
-  beforeEach(async () => {
-    element = await fixture(`<mq-element></mq-element>`);
+      @property({ type: Boolean }) fullscreen: boolean | null | undefined;
+    }
+
+    let element: MqBasicElement;
+
+    beforeEach(async () => {
+      element = await fixture(`<mq-basic-element></mq-basic-element>`);
+    });
+
+    it('should set property value to undefined by default', () => {
+      expect(element.fullscreen).to.be.undefined;
+    });
+
+    it('should set property value to true when query matches', async () => {
+      runQuery(FULLSCREEN, true);
+      await element.updateComplete;
+      expect(element.fullscreen).to.be.true;
+    });
+
+    it('should allow to override property value using setAttribute', async () => {
+      element.setAttribute('fullscreen', '');
+      await element.updateComplete;
+      expect(element.fullscreen).to.be.true;
+    });
+
+    // TODO
+    it.skip('should not discard overridden value on media query change', async () => {
+      element.setAttribute('fullscreen', '');
+      await element.updateComplete;
+      runQuery(FULLSCREEN, false);
+      await element.updateComplete;
+      expect(element.fullscreen).to.be.true;
+    });
+
+    // TODO
+    it.skip('should handle media query change after removeAttribute', async () => {
+      element.setAttribute('fullscreen', '');
+      await element.updateComplete;
+      element.removeAttribute('fullscreen');
+      await element.updateComplete;
+      runQuery(FULLSCREEN, true);
+      await element.updateComplete;
+      expect(element.fullscreen).to.be.true;
+    });
+  });
+
+  describe('custom CSS property', () => {
+    document.documentElement.style.setProperty('--vaadin-responsive', RESPONSIVE);
+
+    @customElement('mq-custom-element')
+    class MqCustomElement extends MqElementBase {
+      static get mediaQueries() {
+        return {
+          responsive: window
+            .getComputedStyle(document.documentElement)
+            .getPropertyValue('--vaadin-responsive')
+            .trim()
+        };
+      }
+
+      @property({ type: Boolean }) responsive: boolean | null | undefined;
+    }
+
+    let element: MqCustomElement;
+
+    beforeEach(async () => {
+      element = await fixture(`<mq-custom-element></mq-custom-element>`);
+      runQuery(RESPONSIVE, true);
+      await element.updateComplete;
+    });
+
+    it('should handle media query set from custom CSS property', () => {
+      expect(element.responsive).to.be.true;
+    });
+
+    it('should change property value when media query changes', async () => {
+      runQuery(RESPONSIVE, false);
+      await element.updateComplete;
+      expect(element.responsive).to.be.false;
+    });
+
+    it('should not change when custom CSS property value changes', async () => {
+      const BREAKPOINT = '(min-width: 768px)';
+      document.documentElement.style.setProperty('--vaadin-responsive', BREAKPOINT);
+      runQuery(BREAKPOINT, false);
+      await element.updateComplete;
+      expect(element.responsive).to.be.true;
+    });
   });
 
   afterEach(() => {
@@ -61,15 +146,5 @@ describe('MediaQueryMixin', () => {
 
   after(() => {
     window.matchMedia = origMatchMedia;
-  });
-
-  it('should set property value to undefined by default', () => {
-    expect(element.fullscreen).to.be.undefined;
-  });
-
-  it('should set property value to true when query matches', async () => {
-    runQuery(FULLSCREEN, true);
-    await element.updateComplete;
-    expect(element.fullscreen).to.be.true;
   });
 });

--- a/packages/media-query-mixin/tsconfig.json
+++ b/packages/media-query-mixin/tsconfig.json
@@ -5,6 +5,6 @@
     "composite": true
   },
   "include": [
-    "media-query-mixin.ts"
+    "media-query-*.ts"
   ]
 }

--- a/packages/media-query-mixin/tsconfig.json
+++ b/packages/media-query-mixin/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "outDir": ".",
+  "compilerOptions": {
+    "composite": true
+  },
+  "include": [
+    "media-query-mixin.ts"
+  ]
+}


### PR DESCRIPTION
Fixes #36 

The implementation that we ended up while discussing with @yuriy-fix looks like this:

```ts
@customElement('mq-basic-element')
class MyElement extends MediaQueryMixin(LitElement) {

  @mediaProperty({ media: '(max-width: 420px)' }) 
  fullscreen: boolean | null | undefined;
}
```

TL;DR: `true` when query matches, and `false` otherwise.

- `attribute: false` is forced so we ignore setting attribute
- property is read-only so we ignore manual modifications