### PR TITLE
Extract matchMedia helpers for reusing in components

### DIFF
--- a/packages/media-query-mixin/package.json
+++ b/packages/media-query-mixin/package.json
@@ -19,7 +19,8 @@
     "lit-html": "^1.0.0"
   },
   "devDependencies": {
-    "@open-wc/testing-helpers": "^1.2.1"
+    "@open-wc/testing-helpers": "^1.2.1",
+    "@vaadin/test-helpers": "^0.1.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/test-helpers/index.ts
+++ b/packages/test-helpers/index.ts
@@ -1,2 +1,3 @@
 export * from './events';
 export * from './keys';
+export * from './media';

--- a/packages/test-helpers/media.ts
+++ b/packages/test-helpers/media.ts
@@ -1,0 +1,32 @@
+const listeners: { [key: string]: () => void } = {};
+const queryMatches: { [key: string]: boolean } = {};
+
+export const matchMedia = (query: string, matches: boolean) => {
+  queryMatches[query] = matches;
+  listeners[query] && listeners[query]();
+};
+
+const origMatchMedia = window.matchMedia;
+window.matchMedia = (query: string) => {
+  return {
+    get matches() {
+      return queryMatches[query] as boolean;
+    },
+    addListener(listener: () => void) {
+      listeners[query] = listener;
+    },
+    removeListener(_listener) {
+      delete listeners[query];
+    }
+  } as MediaQueryList;
+};
+
+export const resetMatchMedia = () => {
+  Object.keys(queryMatches).forEach(key => {
+    delete queryMatches[key];
+  });
+};
+
+export const restoreMatchMedia = () => {
+  window.matchMedia = origMatchMedia;
+};


### PR DESCRIPTION
Added new helpers that will be used in `vaadin-app-layout` unit tests.