### PR TITLE
Implement keyboard mixin for internal usage by other mixins

### DIFF
--- a/packages/active-state-mixin/active-state-class.ts
+++ b/packages/active-state-mixin/active-state-class.ts
@@ -1,10 +1,6 @@
 import { LitElement } from 'lit-element';
 
 export abstract class ActiveStateClass extends LitElement {
-  protected _onKeyDown?(event: KeyboardEvent): void;
-
-  protected _onKeyUp?(event: KeyboardEvent): void;
-
   protected _onMouseDown?(event: MouseEvent): void;
 
   protected _onTouchStart?(event: TouchEvent): void;

--- a/packages/active-state-mixin/active-state-mixin.ts
+++ b/packages/active-state-mixin/active-state-mixin.ts
@@ -1,27 +1,23 @@
 import { PropertyValues } from 'lit-element';
 import { DisabledStateInterface } from '@vaadin/disabled-state-mixin';
+import { KeyboardMixin } from '@vaadin/keyboard-mixin/keyboard-mixin.js';
+import { KeyboardClass } from '@vaadin/keyboard-mixin/keyboard-class.js';
 import { ActiveStateClass } from './active-state-class';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Constructor<T = object> = new (...args: any[]) => T;
 
-export const ActiveStateMixin = <T extends Constructor<DisabledStateInterface & ActiveStateClass>>(
+export const ActiveStateMixin = <
+  T extends Constructor<DisabledStateInterface & ActiveStateClass & KeyboardClass>
+>(
   base: T
 ): T & Constructor<ActiveStateClass> => {
-  class ActiveState extends base {
+  class ActiveState extends KeyboardMixin(base) {
     protected firstUpdated(props: PropertyValues) {
       super.firstUpdated(props);
 
       this.addEventListener('mousedown', (event: MouseEvent) => {
         this._onMouseDown(event);
-      });
-
-      this.addEventListener('keydown', (event: KeyboardEvent) => {
-        this._onKeyDown(event);
-      });
-
-      this.addEventListener('keyup', (event: KeyboardEvent) => {
-        this._onKeyUp(event);
       });
 
       this.addEventListener('touchstart', (event: TouchEvent) => {
@@ -44,13 +40,15 @@ export const ActiveStateMixin = <T extends Constructor<DisabledStateInterface & 
     }
 
     protected _onKeyDown(event: KeyboardEvent) {
+      super._onKeyDown && super._onKeyDown(event);
       if (/^( |SpaceBar|Enter)$/.test(event.key) && !this.disabled && !event.defaultPrevented) {
         event.preventDefault();
         this._setActive(true);
       }
     }
 
-    protected _onKeyUp(_event: KeyboardEvent) {
+    protected _onKeyUp(event: KeyboardEvent) {
+      super._onKeyUp && super._onKeyUp(event);
       this._setActive(false);
     }
 

--- a/packages/active-state-mixin/package.json
+++ b/packages/active-state-mixin/package.json
@@ -16,6 +16,7 @@
   ],
   "dependencies": {
     "@vaadin/disabled-state-mixin": "^0.1.0",
+    "@vaadin/keyboard-mixin": "^0.0.0",
     "lit-element": "^2.0.0",
     "lit-html": "^1.0.0"
   },

--- a/packages/control-state-mixin/package.json
+++ b/packages/control-state-mixin/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@vaadin/disabled-state-mixin": "^0.1.0",
     "@vaadin/focus-visible-mixin": "^0.1.2",
+    "@vaadin/keyboard-mixin": "^0.0.0",
     "lit-element": "^2.0.0",
     "lit-html": "^1.0.0"
   },

--- a/packages/keyboard-direction-mixin/keyboard-direction-class.ts
+++ b/packages/keyboard-direction-mixin/keyboard-direction-class.ts
@@ -6,6 +6,4 @@ export abstract class KeyboardDirectionClass extends LitElement {
   protected _isNextKey?(key: string): boolean;
 
   protected _isPrevKey?(key: string): boolean;
-
-  protected _onKeyDown?(event: KeyboardEvent): void;
 }

--- a/packages/keyboard-direction-mixin/keyboard-direction-mixin.ts
+++ b/packages/keyboard-direction-mixin/keyboard-direction-mixin.ts
@@ -1,7 +1,8 @@
-import { PropertyValues } from 'lit-element';
 import { SlottedItemsInterface } from '@vaadin/slotted-items-mixin';
 import { DirectionMixin } from '@vaadin/direction-mixin/direction-mixin.js';
 import { DirectionClass } from '@vaadin/direction-mixin/direction-class.js';
+import { KeyboardMixin } from '@vaadin/keyboard-mixin/keyboard-mixin.js';
+import { KeyboardClass } from '@vaadin/keyboard-mixin/keyboard-class.js';
 import { KeyboardDirectionClass } from './keyboard-direction-class';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -49,11 +50,13 @@ export const getAvailableIndex = (
 };
 
 export const KeyboardDirectionMixin = <
-  T extends Constructor<SlottedItemsInterface & KeyboardDirectionClass & DirectionClass>
+  T extends Constructor<
+    SlottedItemsInterface & KeyboardDirectionClass & KeyboardClass & DirectionClass
+  >
 >(
   base: T
-): Constructor<DirectionClass & KeyboardDirectionClass & KeyboardDirectionInterface> & T => {
-  const Base = DirectionMixin(base);
+): Constructor<KeyboardDirectionInterface> & T => {
+  const Base = KeyboardMixin(DirectionMixin(base));
 
   class KeyboardDirection extends Base {
     focus() {
@@ -69,15 +72,8 @@ export const KeyboardDirectionMixin = <
       return root ? (root.activeElement as HTMLElement) : null;
     }
 
-    protected firstUpdated(props: PropertyValues) {
-      super.firstUpdated(props);
-
-      this.addEventListener('keydown', (event: KeyboardEvent) => {
-        this._onKeyDown(event);
-      });
-    }
-
     protected _onKeyDown(event: KeyboardEvent) {
+      super._onKeyDown && super._onKeyDown(event);
       if (event.metaKey || event.ctrlKey) {
         return;
       }

--- a/packages/keyboard-direction-mixin/package.json
+++ b/packages/keyboard-direction-mixin/package.json
@@ -16,6 +16,7 @@
   ],
   "dependencies": {
     "@vaadin/direction-mixin": "^0.1.0",
+    "@vaadin/keyboard-mixin": "^0.0.0",
     "@vaadin/slotted-items-mixin": "^0.1.3",
     "lit-element": "^2.0.0",
     "lit-html": "^1.0.0"

--- a/packages/keyboard-mixin/LICENSE
+++ b/packages/keyboard-mixin/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2019 Vaadin Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/keyboard-mixin/README.md
+++ b/packages/keyboard-mixin/README.md
@@ -1,0 +1,3 @@
+# @vaadin/keyboard-mixin
+
+This package provides an internal `KeyboardMixin` that adds `keydown` and `keyup` event listeners.

--- a/packages/keyboard-mixin/keyboard-class.ts
+++ b/packages/keyboard-mixin/keyboard-class.ts
@@ -1,0 +1,7 @@
+import { LitElement } from 'lit-element';
+
+export abstract class KeyboardClass extends LitElement {
+  protected _onKeyDown?(_event: KeyboardEvent): void;
+
+  protected _onKeyUp?(_event: KeyboardEvent): void;
+}

--- a/packages/keyboard-mixin/keyboard-mixin.ts
+++ b/packages/keyboard-mixin/keyboard-mixin.ts
@@ -1,0 +1,37 @@
+import { PropertyValues } from 'lit-element';
+import { Constructor, applyMixin, wasApplied } from '@vaadin/mixin-utils';
+import { KeyboardClass } from './keyboard-class';
+
+export function KeyboardMixin<T extends Constructor<KeyboardClass>>(
+  base: T
+): Constructor<KeyboardClass> & T {
+  if (wasApplied(KeyboardMixin, base)) {
+    return base;
+  }
+
+  class Keyboard extends base {
+    protected firstUpdated(props: PropertyValues) {
+      super.firstUpdated(props);
+
+      this.addEventListener('keydown', (event: KeyboardEvent) => {
+        this._onKeyDown(event);
+      });
+
+      this.addEventListener('keyup', (event: KeyboardEvent) => {
+        this._onKeyUp(event);
+      });
+    }
+
+    protected _onKeyDown(_event: KeyboardEvent) {
+      // to be implemented
+    }
+
+    protected _onKeyUp(_event: KeyboardEvent) {
+      // to be implemented
+    }
+  }
+
+  applyMixin(KeyboardMixin, Keyboard);
+
+  return Keyboard;
+}

--- a/packages/keyboard-mixin/package.json
+++ b/packages/keyboard-mixin/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@vaadin/keyboard-mixin",
+  "version": "0.0.0",
+  "author": "Vaadin Ltd",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vaadin/component-mixins.git",
+    "directory": "packages/keyboard-mixin"
+  },
+  "main": "keyboard-mixin.js",
+  "module": "keyboard-mixin.js",
+  "files": [
+    "keyboard-*.d.ts*",
+    "keyboard-*.js*"
+  ],
+  "dependencies": {
+    "@vaadin/mixin-utils": "^0.0.0",
+    "lit-element": "^2.0.0",
+    "lit-html": "^1.0.0"
+  },
+  "devDependencies": {
+    "@open-wc/testing-helpers": "^1.2.1",
+    "@vaadin/test-helpers": "^0.1.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/keyboard-mixin/test/keyboard-mixin.test.ts
+++ b/packages/keyboard-mixin/test/keyboard-mixin.test.ts
@@ -1,0 +1,53 @@
+import { LitElement, customElement, html } from 'lit-element';
+import { fixture } from '@open-wc/testing-helpers';
+import { enterKeyDown, enterKeyUp } from '@vaadin/test-helpers';
+import { KeyboardMixin } from '../keyboard-mixin';
+
+const { expect } = chai;
+const { sinon } = window;
+
+const Base = KeyboardMixin(LitElement);
+
+@customElement('km-element')
+class KmElement extends KeyboardMixin(Base) {
+  render() {
+    return html`
+      Content
+    `;
+  }
+
+  constructor() {
+    super();
+    this.setAttribute('tabindex', '0');
+  }
+
+  protected _onKeyDown(_event: KeyboardEvent) {
+    this.dispatchEvent(new CustomEvent('keydown-fired'));
+  }
+
+  protected _onKeyUp(_event: KeyboardEvent) {
+    this.dispatchEvent(new CustomEvent('keyup-fired'));
+  }
+}
+
+describe('KeyboardMixin', () => {
+  let element: KmElement;
+
+  beforeEach(async () => {
+    element = await fixture(`<km-element></km-element>`);
+  });
+
+  it('should only invoke keydown event handler once', () => {
+    const spy = sinon.spy();
+    element.addEventListener('keydown-fired', spy);
+    enterKeyDown(element);
+    expect(spy).to.be.calledOnce;
+  });
+
+  it('should only invoke keyup event handler once', () => {
+    const spy = sinon.spy();
+    element.addEventListener('keyup-fired', spy);
+    enterKeyUp(element);
+    expect(spy).to.be.calledOnce;
+  });
+});

--- a/packages/keyboard-mixin/tsconfig.json
+++ b/packages/keyboard-mixin/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "outDir": ".",
+  "compilerOptions": {
+    "composite": true
+  },
+  "include": [
+    "keyboard-*.ts"
+  ]
+}


### PR DESCRIPTION
Fixes #46

The whole idea of having such a mixin is to only add event listeners once per prototype chain.
Implementations of the event handlers must call `super._onKeyDown` / `super._onKeyUp`.