### PR TITLE
refactor(active-state-mixin): expose mouseup listener

### DIFF
--- a/packages/active-state-mixin/active-state-class.ts
+++ b/packages/active-state-mixin/active-state-class.ts
@@ -3,6 +3,8 @@ import { LitElement } from 'lit-element';
 export abstract class ActiveStateClass extends LitElement {
   protected _onMouseDown?(event: MouseEvent): void;
 
+  protected _onMouseUp?(event: MouseEvent): void;
+
   protected _onTouchStart?(event: TouchEvent): void;
 
   protected _onTouchEnd?(event: TouchEvent): void;

--- a/packages/active-state-mixin/active-state-mixin.ts
+++ b/packages/active-state-mixin/active-state-mixin.ts
@@ -58,12 +58,16 @@ export const ActiveStateMixin = <
 
       this._setActive(true);
 
-      const upListener = () => {
-        this._setActive(false);
+      const upListener = (e: MouseEvent) => {
+        this._onMouseUp(e);
         document.removeEventListener('mouseup', upListener);
       };
 
       document.addEventListener('mouseup', upListener);
+    }
+
+    protected _onMouseUp(_event: MouseEvent) {
+      this._setActive(false);
     }
 
     protected _onTouchStart(_event: TouchEvent) {


### PR DESCRIPTION
This change will allow us to use existing listeners in `RadioButton` and avoid having a new one.